### PR TITLE
Enabled hashtable

### DIFF
--- a/src/js/test.js
+++ b/src/js/test.js
@@ -109,9 +109,6 @@ for (let [testname, test] of Object.entries(tests)) {
         if (name == REFERENCE_IMPL)
             continue;
 
-        if (name == 'hashtable')
-            continue;
-
         runTestCase(name);
 
         let same = compareDiffs(diffs[name], diffs[REFERENCE_IMPL]);


### PR DESCRIPTION
This may quietly crash node via memory corruption.